### PR TITLE
🐛 Fix ShowOptions to preserve menu on invalid input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)  
 and the project uses [Semantic Versioning](https://semver.org/).
 
+## [v1.0.2] - 2025-06-23
+### Fixed
+- 🐛 Fixed an issue where menu content was cleared after invalid input in `ShowOptions`. The method now retains the full menu and shows error messages without disrupting context.
+
 ## [v1.0.1] - 2025-06-12
 ### Fixed
 - 🐛 Fixed embedded resource loading issue by allowing `JsonFromEmbeddedResource` to receive an `Assembly` parameter. This enables loading resources from the main executable.

--- a/QuantumKit/UI/ConsoleMenu.cs
+++ b/QuantumKit/UI/ConsoleMenu.cs
@@ -4,12 +4,8 @@ namespace QuantumKit.UI
 {
     public static class ConsoleMenuBuilder
     {
-        #region Constants
         private const double ErrorValue = -1;
-        #endregion
 
-
-        #region Option Menus
         public static void ShowAndProcessMenu(
             string title,
             string subtitle,
@@ -96,8 +92,6 @@ namespace QuantumKit.UI
         }
 
 
-        #endregion
-        #region Ask Menus
         public static int AskInt(string question, (double min, double max)? range = null, bool showError = true)
         {
             return (int)AskDouble(question, range, showError);
@@ -325,8 +319,6 @@ namespace QuantumKit.UI
             }
         }
 
-        #endregion
-        #region Pause and Exit
         public static void Pause(string? customMessage = null)
         {
             string message = customMessage ?? "Presiona cualquier tecla para continuar...";
@@ -339,8 +331,6 @@ namespace QuantumKit.UI
             Environment.Exit(0);
         }
 
-        #endregion
-        #region Info Menus
         public static void ShowErrorEmptyMenu() { ShowError("Error de Menú", "No se han definido opciones para este menú."); }
         public static void ShowErrorBadOption() { ShowError("Error de Selección", "La opción seleccionada no fue procesada correctamente."); }
         public static void ShowError(string title = "¡Error!", string subtitle = "Se presentó un error", string? errorCode = null, ConsoleColor? color = null)
@@ -356,7 +346,6 @@ namespace QuantumKit.UI
             if (color != null) { Console.ResetColor(); }
             Console.Clear();
         }
-        #endregion
     }
     public class MenuItem
     {

--- a/QuantumKit/UI/ConsoleMenu.cs
+++ b/QuantumKit/UI/ConsoleMenu.cs
@@ -83,7 +83,9 @@ namespace QuantumKit.UI
 
                 Console.WriteLine($"0) {exitOrReturnTextOverride ?? (returnInsteadOfExit ? "Volver" : "Salir")}");
 
-                choice = AskInt("Selecciona una opción: ", (0, options.Length), showError);
+                choice = AskInt("Selecciona una opción: ", (0, options.Length), false);
+
+                if (choice == ErrorValue && showError) ShowError("Entrada inválida", $"Debe ser un número válido entre {0} y {options.Length}");
 
             } while (choice == ErrorValue && showError);
 
@@ -138,11 +140,11 @@ namespace QuantumKit.UI
             string first = defaultIfInvalid && defaultFirst ? trueKey.ToString().ToUpper() : trueKey.ToString().ToLower();
             string second = defaultIfInvalid && defaultFirst ? falseKey.ToString().ToLower() : falseKey.ToString().ToUpper();
 
-            return AskBinaryOption(question:question,
-                                    trueLabel:first, falseLabel:second,
-                                    showError:showError,
-                                    defaultIfInvalid:defaultIfInvalid,
-                                    defaultFirst:defaultFirst);
+            return AskBinaryOption(question: question,
+                                    trueLabel: first, falseLabel: second,
+                                    showError: showError,
+                                    defaultIfInvalid: defaultIfInvalid,
+                                    defaultFirst: defaultFirst);
         }
         public static bool AskBinaryOption(
             string question,
@@ -170,7 +172,7 @@ namespace QuantumKit.UI
             if (defaultFirst && !defaultIfInvalid)
                 (firstOption, secondOption) = (falseLabel, trueLabel);
 
-            string optionsDisplay =$"({firstOption}/{secondOption})";
+            string optionsDisplay = $"({firstOption}/{secondOption})";
 
             while (true)
             {


### PR DESCRIPTION
### Summary
This PR fixes a UI issue in the `ShowOptions` method where the menu was cleared after an invalid input. Instead of clearing the console via `AskInt`, we now show the error using `ShowError` while retaining the menu content.

### Changes
- Modified input handling logic in `ShowOptions`.
- Avoided clearing the screen from AskInt when input is invalid.

### Motivation
The previous behavior caused poor user experience in CLI menus, especially when navigating large option lists. This change improves consistency and usability.

### Related
- Version bump: v1.0.2
- Commit: 🐛 fix(ui): preserve menu content when invalid input is entered in ShowOptions
